### PR TITLE
Add Hello World MCP example

### DIFF
--- a/mcp/hello-world/README.md
+++ b/mcp/hello-world/README.md
@@ -1,0 +1,24 @@
+# Hello World MCP Server
+
+This simple example demonstrates how to create an MCP server that replies with
+`"world"` whenever the input to its tool is `"hello"`.
+
+## Running the Server
+
+1. Install the MCP Python SDK. From the repository root you can run:
+
+```bash
+uv pip install -r mcp/crash-course/requirements.txt
+```
+
+2. Start the server using the MCP CLI in development mode:
+
+```bash
+mcp dev server.py
+```
+
+3. In the MCP Inspector, call the `hello` tool with the argument `word="hello"`.
+It will respond with `world`.
+
+You can also run the server directly with `python server.py` and connect using
+any MCP-compatible client.

--- a/mcp/hello-world/server.py
+++ b/mcp/hello-world/server.py
@@ -1,0 +1,13 @@
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("HelloWorld")
+
+@mcp.tool()
+def hello(word: str) -> str:
+    """Return 'world' when the input word is 'hello'."""
+    if word.lower().strip() == "hello":
+        return "world"
+    return "I only respond to 'hello'."
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Summary
- add a minimal Hello World server example for MCP
- document how to run the server using the MCP CLI

## Testing
- `python -m py_compile mcp/hello-world/server.py`